### PR TITLE
Update execute.py

### DIFF
--- a/Powerfactory/execute.py
+++ b/Powerfactory/execute.py
@@ -84,6 +84,20 @@ options.QPFspInputName : str = thisScript.GetInputParameterString('QPFspSignal')
 options.QmodeVar : PF.DataObject = thisScript.GetExternalObject('QmodeVar')[1]
 options.QUmodeVar : PF.DataObject = thisScript.GetExternalObject('QUmodeVar')[1]
 options.QPFmodeVar : PF.DataObject = thisScript.GetExternalObject('QPFmodeVar')[1]
+    
+#Check script Input parameters
+ErrPspSignal = (options.PspInputName=="")
+if ErrPspSignal==True:
+  app.PrintWarn('The name of the Plant P setpoint signal/parameter name (PspSignal) is empty')
+ErrQspSignal = (options.QspInputName=="")
+if ErrQspSignal==True:
+  app.PrintWarn('The name of the Plant Q setpoint signal/parameter name (QspSignal) is empty')
+ErrQUspSignal = (options.QUspInputName=="")
+if ErrQUspSignal==True:
+  app.PrintWarn('The name of the Plant Q(u) setpoint signal/parameter name (QUspSignal) is empty')
+ErrQPFspSignal = (options.QPFspInputName=="")
+if ErrQPFspSignal==True:
+  app.PrintWarn('The name of the Plant powerfactor setpoint signal/parameter name (QPFspSignal) is empty')
 
 # Internal options
 options.studyTime : int = 2**32-1
@@ -274,8 +288,16 @@ if options.setup and not forceNoSetup:
       evLastEvent = evStart
       case.events.append([evStart,evSp,evRp])
       eIndex += 1
-
-    setupCase(app, subScripts, options, plantInfo, grid, activeGrids, case, studyCaseSet, studyCaseFolder, baseVar, baseStage, varFolder, taskAuto)
+    if ErrPspSignal == True and case.PrefCtrl == 1:
+      app.PrintWarn('Study case: '+case.TestType+' will be ignored. No PspSignal entered in script.')  
+    elif ErrQspSignal == True and case.QrefCtrl == 1:
+      app.PrintWarn('Study case: '+case.TestType+' will be ignored. No QspSignal entered in script.')
+    elif ErrQUspSignal == True and case.internalQmode == 1:
+      app.PrintWarn('Study case: '+case.TestType+' will be ignored. No QUspSignal entered in script.') 
+    elif ErrQPFspSignal == True and case.internalQmode == 2:
+      app.PrintWarn('Study case: '+case.TestType+' will be ignored. No QPFspSignal entered in script.')     
+    else:
+      setupCase(app, subScripts, options, plantInfo, grid, activeGrids, case, studyCaseSet, studyCaseFolder, baseVar, baseStage, varFolder, taskAuto)
 
 app.EchoOn()
 if options.run and not forceNoRun:

--- a/Powerfactory/execute.py
+++ b/Powerfactory/execute.py
@@ -87,16 +87,16 @@ options.QPFmodeVar : PF.DataObject = thisScript.GetExternalObject('QPFmodeVar')[
     
 #Check script Input parameters
 ErrPspSignal = (options.PspInputName=="")
-if ErrPspSignal==True:
+if ErrPspSignal:
   app.PrintWarn('The name of the Plant P setpoint signal/parameter name (PspSignal) is empty')
 ErrQspSignal = (options.QspInputName=="")
-if ErrQspSignal==True:
+if ErrQspSignal:
   app.PrintWarn('The name of the Plant Q setpoint signal/parameter name (QspSignal) is empty')
 ErrQUspSignal = (options.QUspInputName=="")
-if ErrQUspSignal==True:
+if ErrQUspSignal:
   app.PrintWarn('The name of the Plant Q(u) setpoint signal/parameter name (QUspSignal) is empty')
 ErrQPFspSignal = (options.QPFspInputName=="")
-if ErrQPFspSignal==True:
+if ErrQPFspSignal:
   app.PrintWarn('The name of the Plant powerfactor setpoint signal/parameter name (QPFspSignal) is empty')
 
 # Internal options
@@ -288,13 +288,14 @@ if options.setup and not forceNoSetup:
       evLastEvent = evStart
       case.events.append([evStart,evSp,evRp])
       eIndex += 1
-    if ErrPspSignal == True and case.PrefCtrl == 1:
+
+    if ErrPspSignal and case.PrefCtrl == 1:
       app.PrintWarn('Study case: '+case.TestType+' will be ignored. No PspSignal entered in script.')  
-    elif ErrQspSignal == True and case.QrefCtrl == 1:
+    elif ErrQspSignal and case.QrefCtrl == 1:
       app.PrintWarn('Study case: '+case.TestType+' will be ignored. No QspSignal entered in script.')
-    elif ErrQUspSignal == True and case.internalQmode == 1:
+    elif ErrQUspSignal and case.internalQmode == 1:
       app.PrintWarn('Study case: '+case.TestType+' will be ignored. No QUspSignal entered in script.') 
-    elif ErrQPFspSignal == True and case.internalQmode == 2:
+    elif ErrQPFspSignal and case.internalQmode == 2:
       app.PrintWarn('Study case: '+case.TestType+' will be ignored. No QPFspSignal entered in script.')     
     else:
       setupCase(app, subScripts, options, plantInfo, grid, activeGrids, case, studyCaseSet, studyCaseFolder, baseVar, baseStage, varFolder, taskAuto)


### PR DESCRIPTION
I am working with the v0.7 version of the code and I think I might have a hint for this issue:
Empty signalnames (PspSignal, QspSignal, QUspSignal, QPFspSignal) causes crash #62

I have added some lines of code to the execute.py script to check the input signals of the script and print a warning if any of these are empty. I have added this after the block (# For the Pref and Qref tests). This code will just check if the variable is empty and print a warning in the PowerFactory output window as stated in the issue description by matbkri. It will also create four "Error" variables, one for each input signal for later use:

#Check script Input parameters
ErrPspSignal = (options.PspInputName=="")
if ErrPspSignal==True:
  app.PrintWarn('The name of the Plant P setpoint signal/parameter name (PspSignal) is empty')
ErrQspSignal = (options.QspInputName=="")
if ErrQspSignal==True:
  app.PrintWarn('The name of the Plant Q setpoint signal/parameter name (QspSignal) is empty')
ErrQUspSignal = (options.QUspInputName=="")
if ErrQUspSignal==True:
  app.PrintWarn('The name of the Plant Q(u) setpoint signal/parameter name (QUspSignal) is empty')
ErrQPFspSignal = (options.QPFspInputName=="")
if ErrQPFspSignal==True:
  app.PrintWarn('The name of the Plant powerfactor setpoint signal/parameter name (QPFspSignal) is empty')

For the second part of the issue description, I have added some conditions before the script calls the setupCase. These conditions will check if the study case requires some of the setpoint signals and will also check if the signals are empty from the error variables defined before. If the study case requires a setpoint signal and the name of the signal is empty it will not call the setupCase function and will not be studied:

if ErrPspSignal == True and case.PrefCtrl == 1:
      app.PrintWarn('Study case: '+case.TestType+' will be ignored. No PspSignal entered in script.')  
    elif ErrQspSignal == True and case.QrefCtrl == 1:
      app.PrintWarn('Study case: '+case.TestType+' will be ignored. No QspSignal entered in script.')
    elif ErrQUspSignal == True and case.internalQmode == 1:
      app.PrintWarn('Study case: '+case.TestType+' will be ignored. No QUspSignal entered in script.') 
    elif ErrQPFspSignal == True and case.internalQmode == 2:
      app.PrintWarn('Study case: '+case.TestType+' will be ignored. No QPFspSignal entered in script.')     
    else:    
      setupCase(app, subScripts, options, plantInfo, grid, activeGrids, case, studyCaseSet, studyCaseFolder, baseVar, baseStage, varFolder, taskAuto)