### PR TITLE
Update PowerFactory execute.py - Option for enable/disable parallel computing

### DIFF
--- a/Powerfactory/execute.py
+++ b/Powerfactory/execute.py
@@ -63,6 +63,7 @@ options.QUspScale : float = thisScript.GetInputParameterDouble('QUspScale')[1]
 options.QPFspScale : float = thisScript.GetInputParameterDouble('QPFspScale')[1]
 options.QPFmode : int = 0 
 options.paraEventsOnly : bool = bool(thisScript.GetInputParameterInt('paraEventsOnly')[1]) 
+options.parallelComp : bool = bool(thisScript.GetInputParameterInt('parallelComp')[1])
 
 # For the Pref and Qref tests
 options.PCtrl : PF.DataObject = thisScript.GetExternalObject('Pctrl')[1]
@@ -304,6 +305,7 @@ app.EchoOn()
 if options.run and not forceNoRun:
   taskAuto = taskAutoRef.GetAttribute('obj_id')
   if taskAuto:
+    taskAuto.iEnableParal = options.parallelComp    
     taskAuto.Execute()
   else:
     exit('No setup to run.')

--- a/Powerfactory/execute.py
+++ b/Powerfactory/execute.py
@@ -198,7 +198,7 @@ if options.setup and not forceNoSetup:
   taskAuto = studyCaseFolder.CreateObject('ComTasks')
   taskAutoRef.SetAttribute('obj_id', taskAuto)
   taskAuto.SetAttribute('iEnableParal', 1)
-  taskAuto.SetAttribute('parMethod', 0)
+  taskAuto.SetAttribute('parMethod', options.parallelComp)
   (taskAuto.GetAttribute('parallelSetting')).SetAttribute('procTimeOut', 3600) 
   
   currentStudycase.Consolidate()
@@ -304,8 +304,7 @@ if options.setup and not forceNoSetup:
 app.EchoOn()
 if options.run and not forceNoRun:
   taskAuto = taskAutoRef.GetAttribute('obj_id')
-  if taskAuto:
-    taskAuto.iEnableParal = options.parallelComp    
+  if taskAuto:    
     taskAuto.Execute()
   else:
     exit('No setup to run.')


### PR DESCRIPTION
I am proposing these changes for a small enhancement of the tool.

While using this tool in PowerFactory, I noticed that by default it uses parallel computing with all the CPU cores in the task automation. I usually feel this is the fastest way to execute long scripts/calculations in PowerFactory, however in some cases the user might need to use some of the CPU for other tasks. This is why I am proposing this change.

I added an extra Input Parameter on the execute.ComPython object in PowerFactory with these characteristics: Type: int
Name: parallelComp
Value: 1
Unit: 
Description: 1 = Enables parallel computing; 0 = Parallel computing is disabled

Then in the # Read the script options section I have added a line to get this input parameter into the python script: options.parallelComp : bool = bool(thisScript.GetInputParameterInt('parallelComp')[1])

Finally, before executing the task automation, I have set the value of the parallel computing to the script input variable:  taskAuto.iEnableParal = options.parallelComp

These two simple lines give an extra feature for the cases where the user might want to have some of the CPU free. In addition in some cases might be of interest to see in the output window all the information/events/warnings/other while running the tool, this is not possible with parallel computation.