### PR TITLE
Fault starting time should be settable #13-Solutio

### DIFF
--- a/Powerfactory/execute.py
+++ b/Powerfactory/execute.py
@@ -63,6 +63,7 @@ options.QUspScale : float = thisScript.GetInputParameterDouble('QUspScale')[1]
 options.QPFspScale : float = thisScript.GetInputParameterDouble('QPFspScale')[1]
 options.QPFmode : int = 0 
 options.paraEventsOnly : bool = bool(thisScript.GetInputParameterInt('paraEventsOnly')[1]) 
+options.faultStartTime : float = thisScript.GetInputParameterDouble('faultStartTime')[1]
 
 # For the Pref and Qref tests
 options.PCtrl : PF.DataObject = thisScript.GetExternalObject('Pctrl')[1]


### PR DESCRIPTION
I am proposing this small change to the code for the solution of an ongoing issue: Fault starting time should be settable #13.

For this I have added a new input parameter in the ComPython object in PowerFactory: Type: double
Name: faultStartTime
Value: 3
Unit: [s]
Description: Fault starting time

Then I just added a line of code to read the extra input parameter into the options class: options.faultStartTime : float = thisScript.GetInputParameterDouble('faultStartTime')[1]

The options are already sent to the setupCase function.