### PR TITLE
Add option enforced synchronization execute.py

### DIFF
--- a/Powerfactory/execute.py
+++ b/Powerfactory/execute.py
@@ -67,7 +67,8 @@ def readScriptOptions(thisScript) -> SimpleNamespace:
   options.paraEventsOnly : bool = bool(thisScript.GetInputParameterInt('paraEventsOnly')[1]) 
   options.consolidate : bool = bool(thisScript.GetInputParameterInt('consolidate')[1]) 
   options.parallelComp : bool = bool(thisScript.GetInputParameterInt('parallelComp')[1])
-
+  options.enforcedSynch : bool = bool(thisScript.GetInputParameterInt('enforcedSynch')[1])
+    
   # For the Pref and Qref tests
   options.PCtrl = thisScript.GetExternalObject('Pctrl')[1]
   if options.PCtrl == None or not (options.PCtrl.GetClassName() == 'ElmDsl' or options.PCtrl.GetClassName() == 'ElmComp'):


### PR DESCRIPTION
I have added a new input parameter in the execute.ComPython object in PowerFactory with these characteristics: Type: int
Name: enforcedSynch
Value: 1 
Unit: Blank
Description: 1 = Enforced Synchronization
The extra line in this script will get this value in the options list.