### PR TITLE
Update execute.py

### DIFF
--- a/PSCAD/execute.py
+++ b/PSCAD/execute.py
@@ -109,6 +109,11 @@ project_pmr.parameters(ammunition = options.totalRuns, volley = options.volleySi
 
 pscad.run_simulation_sets('PMR')    
 
+# Reenable all the output channels in the model
+outputchannels = project.find_all('master:pgb')
+for output in outputchannels:
+    output.enable()
+
 # Get the build folder of the project
 tempFolder = project.temp_folder
 


### PR DESCRIPTION
There are some cases where after running the tool and making the comparison, there is a need to troubleshoot some cases in PSCAD.

It is a bit annoying having to reenable all the output channels for plotting manually. These extra lines just reenable the output channels once the simulation set execution has finished in PSCAD.